### PR TITLE
update \s*jxTag:(.*) to 1.2.3

### DIFF
--- a/prow/values.yaml
+++ b/prow/values.yaml
@@ -57,7 +57,7 @@ tot:
 buildnum:
   image:
     repository: jenkinsxio/jx
-    jxTag: 1.3.585
+    jxTag:1.2.3
   imagePullPolicy: IfNotPresent
   terminationGracePeriodSeconds: 180
   command:


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed regex: `\s*jxTag:(.*)` to: `1.2.3`